### PR TITLE
fix: conditional check failed for pcp service

### DIFF
--- a/playbooks/server.yml
+++ b/playbooks/server.yml
@@ -25,7 +25,7 @@
       retries: 3
       delay: 5
       register: "result"
-      until: "result | succeeded"
+      until: "result is succeeded"
       loop:
         - "pmcd.service"
         - "pmlogger.service"
@@ -170,7 +170,7 @@
       retries: 3
       delay: 5
       register: "result"
-      until: "result | succeeded"
+      until: "result is succeeded"
       become: true
       loop:
         - "pmcd"


### PR DESCRIPTION
installation failed:

TASK [Manage pcp Service] ******************************************************
fatal: [172.16.15.101]: FAILED! => {"msg": "The conditional check 'result | succeeded' failed. The error was: template error while templating string: no filter named 'succeeded'. String: {% if result | succeeded %} True {% else %} False {% endif %}"}

RUNNING HANDLER [Restart pcp Service] ******************************************
fatal: [172.16.15.101]: FAILED! => {"msg": "The conditional check 'result | succeeded' failed. The error was: template error while templating string: no filter named 'succeeded'. String: {% if result | succeeded %} True {% else %} False {% endif %}"}

changed 
result | succeeded => result is succeeded

solution successfully tested on fedora 31